### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.6-slim
 
 # Enable production settings by default; for development, this can be set to 
 # `false` in `docker run --env`


### PR DESCRIPTION
## Description
Dockerfile uses python3-slim, which used to mean python 3.6
python 3.7 came out June 2018, so python3-slim now means python 3.7, which is incompatible with psycopg 2.7.3.2, Pillow 4.3.0, and Django 1.11
## Pls do 
- [ ] Tested and working
- [ ] Unit tests

## Test plan
make test

